### PR TITLE
[PHP] Add new version `PHP.PHP.8.4` - `8.4.1`

### DIFF
--- a/manifests/p/PHP/PHP/8/4/8.4.1/PHP.PHP.8.4.installer.yaml
+++ b/manifests/p/PHP/PHP/8/4/8.4.1/PHP.PHP.8.4.installer.yaml
@@ -1,5 +1,5 @@
 # Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
 
 PackageIdentifier: PHP.PHP.8.4
 PackageVersion: 8.4.1

--- a/manifests/p/PHP/PHP/8/4/8.4.1/PHP.PHP.8.4.locale.en-US.yaml
+++ b/manifests/p/PHP/PHP/8/4/8.4.1/PHP.PHP.8.4.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
 
 PackageIdentifier: PHP.PHP.8.4
 Description: "PHP (recursive acronym for PHP: Hypertext Preprocessor) is a widely-used open source general-purpose scripting language that is especially suited for web development and can be embedded into HTML."

--- a/manifests/p/PHP/PHP/8/4/8.4.1/PHP.PHP.8.4.yaml
+++ b/manifests/p/PHP/PHP/8/4/8.4.1/PHP.PHP.8.4.yaml
@@ -1,5 +1,5 @@
 # Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
 
 PackageIdentifier: PHP.PHP.8.4
 PackageVersion: 8.4.1


### PR DESCRIPTION
Updates `PHP.PHP.8.4` to PHP `8.4.1`

---

**PHP 8.4.1**
x86 zip Download: https://windows.php.net/downloads/releases/php-8.4.1-Win32-vs17-x86.zip
x86 zip checksum: `f9555e4c85cd66cb6761404dac270f4bcd87947b10a727fc1d4bb99a03bb1060`
x64 zip Download: https://windows.php.net/downloads/releases/php-8.4.1-Win32-vs17-x64.zip
x64 zip Checksum: `020d265aa9aa2759dcd527c16ce4749cb7b8b7f70ec13cac9237f428da2eb6ee`

---

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

---

###### Manifest built [automatically](https://github.com/PHPWatch/php-winget-manifest/actions/runs/12253484375) and [attested](https://github.com/PHPWatch/php-winget-manifest/attestations/3762495) by [PHPWatch/php-winget-manifest](https://github.com/PHPWatch/php-winget-manifest/).

