### PR TITLE
[PHP] Add new version `PHP.PHP.8.4` - `8.4.5`

### DIFF
--- a/manifests/p/PHP/PHP/8/4/8.4.5/PHP.PHP.8.4.installer.yaml
+++ b/manifests/p/PHP/PHP/8/4/8.4.5/PHP.PHP.8.4.installer.yaml
@@ -1,0 +1,32 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+
+PackageIdentifier: PHP.PHP.8.4
+PackageVersion: 8.4.5
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: php.exe
+    PortableCommandAlias: php
+Commands:
+  - php
+  - php84
+UpgradeBehavior: install
+ReleaseDate: 2025-03-12
+ArchiveBinariesDependOnPath: true
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://windows.php.net/downloads/releases/php-8.4.5-Win32-vs17-x64.zip
+    InstallerSha256: e7d71476a4e785c83a235d4ae9deda3b809386735a44d897fb8bbef4fde3f5e4
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+  - Architecture: x86
+    InstallerUrl: https://windows.php.net/downloads/releases/php-8.4.5-Win32-vs17-x86.zip
+    InstallerSha256: 7a87be6fb829728ab33848d391411d931f0366f470033509dbe4f681cf1fe97b
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: Microsoft.VCRedist.2015+.x86
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/manifests/p/PHP/PHP/8/4/8.4.5/PHP.PHP.8.4.locale.en-US.yaml
+++ b/manifests/p/PHP/PHP/8/4/8.4.5/PHP.PHP.8.4.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+
+PackageIdentifier: PHP.PHP.8.4
+Description: "PHP (recursive acronym for PHP: Hypertext Preprocessor) is a widely-used open source general-purpose scripting language that is especially suited for web development and can be embedded into HTML."
+ShortDescription: PHP 8.4
+PackageVersion: 8.4.5
+ReleaseNotesUrl: https://www.php.net/ChangeLog-8.php#8.4.5
+PackageLocale: en-US
+Publisher: PHP Group
+PublisherUrl: https://php.net
+PublisherSupportUrl: https://www.php.net/docs.php
+Author: PHP Group
+PackageName: PHP 8.4
+PackageUrl: https://php.net
+License: PHP License v3.01
+LicenseUrl: https://www.php.net/license/3_01.txt
+Copyright: (c) PHP Group
+CopyrightUrl: https://www.php.net/credits.php
+Moniker: php8.4
+Tags:
+  - php
+  - php84
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/manifests/p/PHP/PHP/8/4/8.4.5/PHP.PHP.8.4.yaml
+++ b/manifests/p/PHP/PHP/8/4/8.4.5/PHP.PHP.8.4.yaml
@@ -1,0 +1,8 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+
+PackageIdentifier: PHP.PHP.8.4
+PackageVersion: 8.4.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
Updates `PHP.PHP.8.4` to PHP `8.4.5`

---

**PHP 8.4.5**
x86 zip Download: https://windows.php.net/downloads/releases/php-8.4.5-Win32-vs17-x86.zip
x86 zip checksum: `7a87be6fb829728ab33848d391411d931f0366f470033509dbe4f681cf1fe97b`
x64 zip Download: https://windows.php.net/downloads/releases/php-8.4.5-Win32-vs17-x64.zip
x64 zip Checksum: `e7d71476a4e785c83a235d4ae9deda3b809386735a44d897fb8bbef4fde3f5e4`

Info: [PHP 8.4](https://windows.php.net/download#php-8.4) - [PHP 8.4.5](https://php.watch/versions/8.4/releases/8.4.5#download-windows) - [php/php-src 8.4.5](https://github.com/php/php-src/releases/tag/php-8.4.5)

---

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

---

###### Manifest built [automatically](https://github.com/PHPWatch/php-winget-manifest/actions/runs/13811948470) and [attested](https://github.com/PHPWatch/php-winget-manifest/attestations/5519021) by [PHPWatch/php-winget-manifest](https://github.com/PHPWatch/php-winget-manifest/).

