### PR TITLE
[PHP] Add new version `PHP.PHP.NTS.8.5` - `8.5.4`

### DIFF
--- a/manifests/p/PHP/PHP/NTS/8/5/8.5.4/PHP.PHP.NTS.8.5.installer.yaml
+++ b/manifests/p/PHP/PHP/NTS/8/5/8.5.4/PHP.PHP.NTS.8.5.installer.yaml
@@ -1,0 +1,32 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: PHP.PHP.NTS.8.5
+PackageVersion: 8.5.4
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: php.exe
+    PortableCommandAlias: php
+Commands:
+  - php
+  - php85
+UpgradeBehavior: install
+ReleaseDate: 2026-03-10
+ArchiveBinariesDependOnPath: true
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://downloads.php.net/~windows/releases/php-8.5.4-nts-Win32-vs17-x64.zip
+    InstallerSha256: 42ac025dbcbd0692d8cf873590653534c5e6b96fedc0a51adb9db6d8a95a977a
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+  - Architecture: x86
+    InstallerUrl: https://downloads.php.net/~windows/releases/php-8.5.4-nts-Win32-vs17-x86.zip
+    InstallerSha256: bf22aa14accdfd92ab701a9e22c0a0300e515d1a0f936c652cb2efcf29ff4d65
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: Microsoft.VCRedist.2015+.x86
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/manifests/p/PHP/PHP/NTS/8/5/8.5.4/PHP.PHP.NTS.8.5.locale.en-US.yaml
+++ b/manifests/p/PHP/PHP/NTS/8/5/8.5.4/PHP.PHP.NTS.8.5.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: PHP.PHP.NTS.8.5
+Description: "PHP (recursive acronym for PHP: Hypertext Preprocessor) is a widely-used open source general-purpose scripting language that is especially suited for web development and can be embedded into HTML."
+ShortDescription: PHP 8.5 - Non-thread safe
+PackageVersion: 8.5.4
+ReleaseNotesUrl: https://www.php.net/ChangeLog-8.php#8.5.4
+PackageLocale: en-US
+Publisher: PHP Group
+PublisherUrl: https://php.net
+PublisherSupportUrl: https://www.php.net/docs.php
+Author: PHP Group
+PackageName: PHP 8.5 - Non-thread safe
+PackageUrl: https://php.net
+License: PHP License v3.01
+LicenseUrl: https://www.php.net/license/3_01.txt
+Copyright: (c) PHP Group
+CopyrightUrl: https://www.php.net/credits.php
+Moniker: php8.5
+Tags:
+  - php
+  - php85
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/manifests/p/PHP/PHP/NTS/8/5/8.5.4/PHP.PHP.NTS.8.5.yaml
+++ b/manifests/p/PHP/PHP/NTS/8/5/8.5.4/PHP.PHP.NTS.8.5.yaml
@@ -1,0 +1,8 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: PHP.PHP.NTS.8.5
+PackageVersion: 8.5.4
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
Updates `PHP.PHP.NTS.8.5` to PHP `8.5.4`

---

**PHP 8.5.4**
x86 zip Download: https://downloads.php.net/~windows/releases/php-8.5.4-nts-Win32-vs17-x86.zip
x86 zip checksum: `bf22aa14accdfd92ab701a9e22c0a0300e515d1a0f936c652cb2efcf29ff4d65`
x64 zip Download: https://downloads.php.net/~windows/releases/php-8.5.4-nts-Win32-vs17-x64.zip
x64 zip Checksum: `42ac025dbcbd0692d8cf873590653534c5e6b96fedc0a51adb9db6d8a95a977a`

Info: [PHP 8.5](https://windows.php.net/download#php-8.5) - [PHP 8.5.4](https://php.watch/versions/8.5/releases/8.5.4#download-windows) - [php/php-src 8.5.4](https://github.com/php/php-src/releases/tag/php-8.5.4)

---

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.10 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.10.0)?

---

###### Manifest built [automatically](https://github.com/PHPWatch/php-winget-manifest/actions/runs/22941191947) and [attested](https://github.com/PHPWatch/php-winget-manifest/attestations/21009491) by [PHPWatch/php-winget-manifest](https://github.com/PHPWatch/php-winget-manifest/).

