### PR TITLE
[PHP] Add new version `PHP.PHP.NTS.8.4` - `8.4.20`

### DIFF
--- a/manifests/p/PHP/PHP/NTS/8/4/8.4.20/PHP.PHP.NTS.8.4.installer.yaml
+++ b/manifests/p/PHP/PHP/NTS/8/4/8.4.20/PHP.PHP.NTS.8.4.installer.yaml
@@ -1,0 +1,32 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: PHP.PHP.NTS.8.4
+PackageVersion: 8.4.20
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: php.exe
+    PortableCommandAlias: php
+Commands:
+  - php
+  - php84
+UpgradeBehavior: install
+ReleaseDate: 2026-04-08
+ArchiveBinariesDependOnPath: true
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://downloads.php.net/~windows/releases/php-8.4.20-nts-Win32-vs17-x64.zip
+    InstallerSha256: bac1a970a676e8d875d5d39fc5ff388f231fadb9fb051b77b17db06a657673df
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+  - Architecture: x86
+    InstallerUrl: https://downloads.php.net/~windows/releases/php-8.4.20-nts-Win32-vs17-x86.zip
+    InstallerSha256: cf202f45dcf7776d8ab2aafe3dd518bb0b3b5d8ccd2d84a9049aa0c5e7af8b66
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: Microsoft.VCRedist.2015+.x86
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/PHP/PHP/NTS/8/4/8.4.20/PHP.PHP.NTS.8.4.locale.en-US.yaml
+++ b/manifests/p/PHP/PHP/NTS/8/4/8.4.20/PHP.PHP.NTS.8.4.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: PHP.PHP.NTS.8.4
+Description: "PHP (recursive acronym for PHP: Hypertext Preprocessor) is a widely-used open source general-purpose scripting language that is especially suited for web development and can be embedded into HTML."
+ShortDescription: PHP 8.4 - Non-thread safe
+PackageVersion: 8.4.20
+ReleaseNotesUrl: https://www.php.net/ChangeLog-8.php#8.4.20
+PackageLocale: en-US
+Publisher: PHP Group
+PublisherUrl: https://php.net
+PublisherSupportUrl: https://www.php.net/docs.php
+Author: PHP Group
+PackageName: PHP 8.4 - Non-thread safe
+PackageUrl: https://php.net
+License: PHP License v3.01
+LicenseUrl: https://www.php.net/license/3_01.txt
+Copyright: (c) PHP Group
+CopyrightUrl: https://www.php.net/credits.php
+Moniker: php8.4
+Tags:
+  - php
+  - php84
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/PHP/PHP/NTS/8/4/8.4.20/PHP.PHP.NTS.8.4.yaml
+++ b/manifests/p/PHP/PHP/NTS/8/4/8.4.20/PHP.PHP.NTS.8.4.yaml
@@ -1,0 +1,8 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: PHP.PHP.NTS.8.4
+PackageVersion: 8.4.20
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates `PHP.PHP.NTS.8.4` to PHP `8.4.20`

---

**PHP 8.4.20**
x86 zip Download: https://downloads.php.net/~windows/releases/php-8.4.20-nts-Win32-vs17-x86.zip
x86 zip checksum: `cf202f45dcf7776d8ab2aafe3dd518bb0b3b5d8ccd2d84a9049aa0c5e7af8b66`
x64 zip Download: https://downloads.php.net/~windows/releases/php-8.4.20-nts-Win32-vs17-x64.zip
x64 zip Checksum: `bac1a970a676e8d875d5d39fc5ff388f231fadb9fb051b77b17db06a657673df`

Info: [PHP 8.4](https://windows.php.net/download#php-8.4) - [PHP 8.4.20](https://php.watch/versions/8.4/releases/8.4.20#download-windows) - [php/php-src 8.4.20](https://github.com/php/php-src/releases/tag/php-8.4.20)

---

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

---

###### Manifest built [automatically](https://github.com/PHPWatch/php-winget-manifest/actions/runs/24128813417) and [attested](https://github.com/PHPWatch/php-winget-manifest/attestations/23765813) by [PHPWatch/php-winget-manifest](https://github.com/PHPWatch/php-winget-manifest/).

