### PR TITLE
[PHP] Add new version `PHP.PHP.8.2` - `8.2.31`

### DIFF
--- a/manifests/p/PHP/PHP/8/2/8.2.31/PHP.PHP.8.2.installer.yaml
+++ b/manifests/p/PHP/PHP/8/2/8.2.31/PHP.PHP.8.2.installer.yaml
@@ -1,0 +1,32 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: PHP.PHP.8.2
+PackageVersion: 8.2.31
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: php.exe
+    PortableCommandAlias: php
+Commands:
+  - php
+  - php82
+UpgradeBehavior: install
+ReleaseDate: 2026-05-05
+ArchiveBinariesDependOnPath: true
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://downloads.php.net/~windows/releases/php-8.2.31-Win32-vs16-x64.zip
+    InstallerSha256: b0c2883017316528cc927f49fd31750baab3b52523c301644454c2f89c4b3de1
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+  - Architecture: x86
+    InstallerUrl: https://downloads.php.net/~windows/releases/php-8.2.31-Win32-vs16-x86.zip
+    InstallerSha256: 136d39b91c904d111c7f921da044cecfa71cde4ee53609f1fbf1e08d9633b69e
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: Microsoft.VCRedist.2015+.x86
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/PHP/PHP/8/2/8.2.31/PHP.PHP.8.2.locale.en-US.yaml
+++ b/manifests/p/PHP/PHP/8/2/8.2.31/PHP.PHP.8.2.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: PHP.PHP.8.2
+Description: "PHP (recursive acronym for PHP: Hypertext Preprocessor) is a widely-used open source general-purpose scripting language that is especially suited for web development and can be embedded into HTML."
+ShortDescription: PHP 8.2
+PackageVersion: 8.2.31
+ReleaseNotesUrl: https://www.php.net/ChangeLog-8.php#8.2.31
+PackageLocale: en-US
+Publisher: PHP Group
+PublisherUrl: https://php.net
+PublisherSupportUrl: https://www.php.net/docs.php
+Author: PHP Group
+PackageName: PHP 8.2
+PackageUrl: https://php.net
+License: PHP License v3.01
+LicenseUrl: https://www.php.net/license/3_01.txt
+Copyright: (c) PHP Group
+CopyrightUrl: https://www.php.net/credits.php
+Moniker: php8.2
+Tags:
+  - php
+  - php82
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/PHP/PHP/8/2/8.2.31/PHP.PHP.8.2.yaml
+++ b/manifests/p/PHP/PHP/8/2/8.2.31/PHP.PHP.8.2.yaml
@@ -1,0 +1,8 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: PHP.PHP.8.2
+PackageVersion: 8.2.31
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates `PHP.PHP.8.2` to PHP `8.2.31`

---

**PHP 8.2.31**
x86 zip Download: https://downloads.php.net/~windows/releases/php-8.2.31-Win32-vs16-x86.zip
x86 zip checksum: `136d39b91c904d111c7f921da044cecfa71cde4ee53609f1fbf1e08d9633b69e`
x64 zip Download: https://downloads.php.net/~windows/releases/php-8.2.31-Win32-vs16-x64.zip
x64 zip Checksum: `b0c2883017316528cc927f49fd31750baab3b52523c301644454c2f89c4b3de1`

Info: [PHP 8.2](https://windows.php.net/download#php-8.2) - [PHP 8.2.31](https://php.watch/versions/8.2/releases/8.2.31#download-windows) - [php/php-src 8.2.31](https://github.com/php/php-src/releases/tag/php-8.2.31)

---

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

---

###### Manifest built [automatically](https://github.com/PHPWatch/php-winget-manifest/actions/runs/25453117968) and [attested](https://github.com/PHPWatch/php-winget-manifest/attestations/26643788) by [PHPWatch/php-winget-manifest](https://github.com/PHPWatch/php-winget-manifest/).

