### PR TITLE
[PHP] Add new version `PHP.PHP.8.5` - `8.5.7`

### DIFF
--- a/manifests/p/PHP/PHP/8/5/8.5.7/PHP.PHP.8.5.installer.yaml
+++ b/manifests/p/PHP/PHP/8/5/8.5.7/PHP.PHP.8.5.installer.yaml
@@ -1,0 +1,32 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: PHP.PHP.8.5
+PackageVersion: 8.5.7
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: php.exe
+    PortableCommandAlias: php
+Commands:
+  - php
+  - php85
+UpgradeBehavior: install
+ReleaseDate: 2026-06-02
+ArchiveBinariesDependOnPath: true
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://downloads.php.net/~windows/releases/php-8.5.7-Win32-vs17-x64.zip
+    InstallerSha256: 0e8a7a368de950408e1df5d34a5a9deb3817e434007f28f310e6674354ed8d06
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+  - Architecture: x86
+    InstallerUrl: https://downloads.php.net/~windows/releases/php-8.5.7-Win32-vs17-x86.zip
+    InstallerSha256: 367e2c8d5ee0288dc2741f71ef715ccf04a5ec78d82cc1d792d58ef9c0a9eea6
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: Microsoft.VCRedist.2015+.x86
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/PHP/PHP/8/5/8.5.7/PHP.PHP.8.5.locale.en-US.yaml
+++ b/manifests/p/PHP/PHP/8/5/8.5.7/PHP.PHP.8.5.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: PHP.PHP.8.5
+Description: "PHP (recursive acronym for PHP: Hypertext Preprocessor) is a widely-used open source general-purpose scripting language that is especially suited for web development and can be embedded into HTML."
+ShortDescription: PHP 8.5
+PackageVersion: 8.5.7
+ReleaseNotesUrl: https://www.php.net/ChangeLog-8.php#8.5.7
+PackageLocale: en-US
+Publisher: PHP Group
+PublisherUrl: https://php.net
+PublisherSupportUrl: https://www.php.net/docs.php
+Author: PHP Group
+PackageName: PHP 8.5
+PackageUrl: https://php.net
+License: PHP License v3.01
+LicenseUrl: https://www.php.net/license/3_01.txt
+Copyright: (c) PHP Group
+CopyrightUrl: https://www.php.net/credits.php
+Moniker: php8.5
+Tags:
+  - php
+  - php85
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/PHP/PHP/8/5/8.5.7/PHP.PHP.8.5.yaml
+++ b/manifests/p/PHP/PHP/8/5/8.5.7/PHP.PHP.8.5.yaml
@@ -1,0 +1,8 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: PHP.PHP.8.5
+PackageVersion: 8.5.7
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates `PHP.PHP.8.5` to PHP `8.5.7`

---

**PHP 8.5.7**
x86 zip Download: https://downloads.php.net/~windows/releases/php-8.5.7-Win32-vs17-x86.zip
x86 zip checksum: `367e2c8d5ee0288dc2741f71ef715ccf04a5ec78d82cc1d792d58ef9c0a9eea6`
x64 zip Download: https://downloads.php.net/~windows/releases/php-8.5.7-Win32-vs17-x64.zip
x64 zip Checksum: `0e8a7a368de950408e1df5d34a5a9deb3817e434007f28f310e6674354ed8d06`

Info: [PHP 8.5](https://windows.php.net/download#php-8.5) - [PHP 8.5.7](https://php.watch/versions/8.5/releases/8.5.7#download-windows) - [php/php-src 8.5.7](https://github.com/php/php-src/releases/tag/php-8.5.7)

---

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

---

###### Manifest built [automatically](https://github.com/PHPWatch/php-winget-manifest/actions/runs/26852882228) and [attested](https://github.com/PHPWatch/php-winget-manifest/attestations/29623602) by [PHPWatch/php-winget-manifest](https://github.com/PHPWatch/php-winget-manifest/).

