### PR TITLE
[PHP] Add new version `PHP.PHP.8.3` - `8.3.32`

### DIFF
--- a/manifests/p/PHP/PHP/8/3/8.3.32/PHP.PHP.8.3.installer.yaml
+++ b/manifests/p/PHP/PHP/8/3/8.3.32/PHP.PHP.8.3.installer.yaml
@@ -1,0 +1,32 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: PHP.PHP.8.3
+PackageVersion: 8.3.32
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: php.exe
+    PortableCommandAlias: php
+Commands:
+  - php
+  - php83
+UpgradeBehavior: install
+ReleaseDate: 2026-07-01
+ArchiveBinariesDependOnPath: true
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://downloads.php.net/~windows/releases/php-8.3.32-Win32-vs16-x64.zip
+    InstallerSha256: 76fe1eafda6dcc8927122adb79088b22e19cfbf81c3dbed44ccb335d1bf8de29
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+  - Architecture: x86
+    InstallerUrl: https://downloads.php.net/~windows/releases/php-8.3.32-Win32-vs16-x86.zip
+    InstallerSha256: fc3033f013636fa6b8d274d6e68e5a1704a155d64faa91c55b484883fdc6b071
+    Dependencies:
+      PackageDependencies:
+        - PackageIdentifier: Microsoft.VCRedist.2015+.x86
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/PHP/PHP/8/3/8.3.32/PHP.PHP.8.3.locale.en-US.yaml
+++ b/manifests/p/PHP/PHP/8/3/8.3.32/PHP.PHP.8.3.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: PHP.PHP.8.3
+Description: "PHP (recursive acronym for PHP: Hypertext Preprocessor) is a widely-used open source general-purpose scripting language that is especially suited for web development and can be embedded into HTML."
+ShortDescription: PHP 8.3
+PackageVersion: 8.3.32
+ReleaseNotesUrl: https://www.php.net/ChangeLog-8.php#8.3.32
+PackageLocale: en-US
+Publisher: PHP Group
+PublisherUrl: https://php.net
+PublisherSupportUrl: https://www.php.net/docs.php
+Author: PHP Group
+PackageName: PHP 8.3
+PackageUrl: https://php.net
+License: PHP License v3.01
+LicenseUrl: https://www.php.net/license/3_01.txt
+Copyright: (c) PHP Group
+CopyrightUrl: https://www.php.net/credits.php
+Moniker: php8.3
+Tags:
+  - php
+  - php83
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/PHP/PHP/8/3/8.3.32/PHP.PHP.8.3.yaml
+++ b/manifests/p/PHP/PHP/8/3/8.3.32/PHP.PHP.8.3.yaml
@@ -1,0 +1,8 @@
+# Created with PHPWatch/winget-pkgs - https://github.com/PHPWatch/php-winget-manifest
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: PHP.PHP.8.3
+PackageVersion: 8.3.32
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Updates `PHP.PHP.8.3` to PHP `8.3.32`

---

**PHP 8.3.32**
x86 zip Download: https://downloads.php.net/~windows/releases/php-8.3.32-Win32-vs16-x86.zip
x86 zip checksum: `fc3033f013636fa6b8d274d6e68e5a1704a155d64faa91c55b484883fdc6b071`
x64 zip Download: https://downloads.php.net/~windows/releases/php-8.3.32-Win32-vs16-x64.zip
x64 zip Checksum: `76fe1eafda6dcc8927122adb79088b22e19cfbf81c3dbed44ccb335d1bf8de29`

Info: [PHP 8.3](https://windows.php.net/download#php-8.3) - [PHP 8.3.32](https://php.watch/versions/8.3/releases/8.3.32#download-windows) - [php/php-src 8.3.32](https://github.com/php/php-src/releases/tag/php-8.3.32)

---

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

---

###### Manifest built [automatically](https://github.com/PHPWatch/php-winget-manifest/actions/runs/28515514084) and [attested](https://github.com/PHPWatch/php-winget-manifest/attestations/33439626) by [PHPWatch/php-winget-manifest](https://github.com/PHPWatch/php-winget-manifest/).

